### PR TITLE
Added: Support for showing the IME Candidate Window on Windows

### DIFF
--- a/include/SDL_hints.h
+++ b/include/SDL_hints.h
@@ -537,6 +537,15 @@ extern "C" {
 #define SDL_HINT_IME_INTERNAL_EDITING "SDL_IME_INTERNAL_EDITING"
 
 /**
+ * \brief A variable to control whether certain IMEs should show native UI components (such as the Candidate List) instead of suppressing them.
+ *
+ * The variable can be set to the following values:
+ *   "0"       - Native UI components are not display. (default)
+ *   "1"       - Native UI components are displayed.
+ */
+#define SDL_HINT_IME_SHOW_UI "SDL_IME_SHOW_UI"
+
+/**
  * \brief  A variable controlling whether the home indicator bar on iPhone X
  *         should be hidden.
  *


### PR DESCRIPTION
## Description
This PR fixes an issue with IME support on Windows where SDL2 windows in a Windowed state were not showing the IME Candidate Window. There were 2 root causes of this issue, the first was the existence of a UI Sink that was not toggleable. The second was a mistake in the code that set the position of the IME Candidate Window. The incorrect structure was being allocated and passed along to the function responsible for setting the Candidate Window's position.
I have added a new SDL hint "SDL_HINT_IME_SHOW_UI", which when true will ensure that the standard IME UI will appear as normal. If left false, default behavior (prior to this commit) is retained. This ensure backwards compatibility.

Future improvements would include the ability to get the current IME Candidate Window's candidate list so that an in-game UI could show its own UI for this feature. This change was made for the context of Desktop Applications using the IME.

## Existing Issue(s)
#4539 - doesn't show IME candidate list in windows 10(chinese Input support)
#2243 - No IME Candidate List visible

## NOTE
This PR is already upstream here https://github.com/libsdl-org/SDL/pull/4707
We need this now for the next beta