### PR TITLE
Fix for SDL_WINDOWEVENT_RESTORED not being generated on MacOS

### DIFF
--- a/src/events/SDL_windowevents.c
+++ b/src/events/SDL_windowevents.c
@@ -84,7 +84,7 @@ SDL_SendWindowEvent(SDL_Window * window, Uint8 windowevent, int data1,
         if (window->flags & SDL_WINDOW_SHOWN) {
             return 0;
         }
-        window->flags &= ~(SDL_WINDOW_HIDDEN | SDL_WINDOW_MINIMIZED);
+        window->flags &= ~SDL_WINDOW_HIDDEN;
         window->flags |= SDL_WINDOW_SHOWN;
         SDL_OnWindowShown(window);
         break;


### PR DESCRIPTION
## Description
On mac, the SDL_cocoawindow observeValueForKeyPath callback generates a SDL_WINDOWEVENT_SHOWN event before the SDL_WINDOWEVENT_RESTORED gets generated. SDL_WINDOWEVENT_SHOWN unsets the SDL_WINDOW_MINIMIZED flag; this in turn causes SDL_WINDOWEVENT_RESTORED event to return before being posted, as the window is neither minimized or maximized.
I also considered calling SDL_SendWindowEvent() from observeValueForKeyPath in SDL_cocoawindow just before we call SendWindowEvent for SDL_WINDOWEVENT_SHOWN - this also fixes the bug, but results in SDL_WINDOWEVENT_RESTORED being generated twice, with the second time returning early due to the window no longer being minimized.
