### PR TITLE
Handle cases where the windows on-screen keyboard sends through alt-key-down events with no scancode field

### DIFF
--- a/src/video/windows/SDL_windowsevents.c
+++ b/src/video/windows/SDL_windowsevents.c
@@ -121,7 +121,10 @@ static SDL_Scancode VKeytoScancodeFallback(WPARAM vkey)
         return SDL_SCANCODE_RIGHT;
     case VK_DOWN:
         return SDL_SCANCODE_DOWN;
-    case VK_CONTROL: return SDL_SCANCODE_LCTRL;
+    case VK_CONTROL:
+        return SDL_SCANCODE_LCTRL;
+    case VK_MENU:
+        return SDL_SCANCODE_LALT;
 
     // SDL_SCANCODE_V cannot be simply assigned here: on a non-QWERTY layout (e.g. Dvorak)
     // it may be mapped to an incorrect key 


### PR DESCRIPTION
Handle cases where the windows on-screen keyboard sends through alt-key-down events with no scancode field.

This occurs when using AltGr, which should send through a Left Control key down event, followed by a Right Alt key down event.
However, due to the malformed scancode field SDL was ignoring the Right Alt key down.
Instead, for events with an Alt virtual key and no Alt scancode, we can "fill in" the scancode key with an Alt scancode.
Since we can't really guarantee what scancode was pressed, we default to the left scancode.