### PR TITLE
Mac DPI issue

### DIFF
--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -425,8 +425,6 @@ int Cocoa_GetDisplayUsableBounds(_THIS, SDL_VideoDisplay * display, SDL_Rect * r
 int Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float * hdpi, float * vdpi)
 { @autoreleasepool
 {
-    const float MM_IN_INCH = 25.4f;
-
     SDL_DisplayData *data = (SDL_DisplayData *) display->driverdata;
 
     /* we need the backingScaleFactor for Retina displays, which is only exposed through NSScreen, not CGDisplay, afaik, so find our screen... */
@@ -436,67 +434,44 @@ int Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float *
     displayNativeSize.width = (int) CGDisplayPixelsWide(data->display);
     displayNativeSize.height = (int) CGDisplayPixelsHigh(data->display);
 
+    /* Sensible defaults */
+    CGFloat windowsCompatibleDpiW = 96.0;
+    CGFloat windowsCompatibleDpiH = 96.0;
+
     for (NSScreen *screen in screens) {
         const CGDirectDisplayID dpyid = (const CGDirectDisplayID ) [[[screen deviceDescription] objectForKey:@"NSScreenNumber"] unsignedIntValue];
         if (dpyid == data->display) {
 #ifdef MAC_OS_X_VERSION_10_8
+
             /* Neither CGDisplayScreenSize(description's NSScreenNumber) nor [NSScreen backingScaleFactor] can calculate the correct dpi in macOS. E.g. backingScaleFactor is always 2 in all display modes for rMBP 16" */
             if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_7) {
-                CFStringRef dmKeys[1] = { kCGDisplayShowDuplicateLowResolutionModes };
-                CFBooleanRef dmValues[1] = { kCFBooleanTrue };
-                CFDictionaryRef dmOptions = CFDictionaryCreate(kCFAllocatorDefault, (const void**) dmKeys, (const void**) dmValues, 1, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks );
-                CFArrayRef allDisplayModes = CGDisplayCopyAllDisplayModes(dpyid, dmOptions);
-                CFIndex n = CFArrayGetCount(allDisplayModes);
-                for(CFIndex i = 0; i < n; ++i) {
-                    CGDisplayModeRef m = (CGDisplayModeRef)CFArrayGetValueAtIndex(allDisplayModes, i);
-                    CGFloat width = CGDisplayModeGetPixelWidth(m);
-                    CGFloat height = CGDisplayModeGetPixelHeight(m);
-                    CGFloat HiDPIWidth = CGDisplayModeGetWidth(m);
-
-                    //Only check 1x mode
-                    if(width == HiDPIWidth) {
-                        if (CGDisplayModeGetIOFlags(m) & kDisplayModeNativeFlag) {
-                            displayNativeSize.width = width;
-                            displayNativeSize.height = height;
-                            break;
-                        }
-
-                        //Get the largest size even if kDisplayModeNativeFlag is not present e.g. iMac 27-Inch with 5K Retina
-                        if(width > displayNativeSize.width) {
-                            displayNativeSize.width = width;
-                            displayNativeSize.height = height;
-                        }
-                    }
-                }
-                CFRelease(allDisplayModes);
-                CFRelease(dmOptions);
+                NSRect framePoints = [screen frame];
+                CGFloat widthPoints  = framePoints.size.width;
+                CGFloat heightPoints = framePoints.size.height;
+                windowsCompatibleDpiW = (displayNativeSize.width / framePoints.size.width) * 96.0;
+                windowsCompatibleDpiH = (displayNativeSize.height / framePoints.size.height) * 96.0;
+                break;
             } else
 #endif
             {
                 // fallback for 10.7
                 scaleFactor = [screen backingScaleFactor];
-                displayNativeSize.width = displayNativeSize.width * scaleFactor;
-                displayNativeSize.height = displayNativeSize.height * scaleFactor;
+                windowsCompatibleDpiW = scaleFactor * 96.0;
+                windowsCompatibleDpiH = scaleFactor * 96.0;
                 break;
             }
         }
     }
 
-    {
-        const CGSize displaySize = CGDisplayScreenSize(data->display);
-        const int pixelWidth =  displayNativeSize.width;
-        const int pixelHeight = displayNativeSize.height;
+    if (ddpi)
+        *ddpi = windowsCompatibleDpiW;  // we don't use this anyway
 
-        if (ddpi) {
-            *ddpi = (SDL_ComputeDiagonalDPI(pixelWidth, pixelHeight, displaySize.width / MM_IN_INCH, displaySize.height / MM_IN_INCH));
-        }
-        if (hdpi) {
-            *hdpi = (pixelWidth * MM_IN_INCH / displaySize.width);
-        }
-        if (vdpi) {
-            *vdpi = (pixelHeight * MM_IN_INCH / displaySize.height);
-        }
-    }
+    if (hdpi)
+        *hdpi = windowsCompatibleDpiW;
+
+    if (vdpi)
+        *vdpi = windowsCompatibleDpiH;
+
     return 0;
 }}
 

--- a/src/video/cocoa/SDL_cocoamodes.m
+++ b/src/video/cocoa/SDL_cocoamodes.m
@@ -430,9 +430,6 @@ int Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float *
     /* we need the backingScaleFactor for Retina displays, which is only exposed through NSScreen, not CGDisplay, afaik, so find our screen... */
     CGFloat scaleFactor = 1.0f;
     NSArray *screens = [NSScreen screens];
-    NSSize displayNativeSize;
-    displayNativeSize.width = (int) CGDisplayPixelsWide(data->display);
-    displayNativeSize.height = (int) CGDisplayPixelsHigh(data->display);
 
     /* Sensible defaults */
     CGFloat windowsCompatibleDpiW = 96.0;
@@ -446,10 +443,18 @@ int Cocoa_GetDisplayDPI(_THIS, SDL_VideoDisplay * display, float * ddpi, float *
             /* Neither CGDisplayScreenSize(description's NSScreenNumber) nor [NSScreen backingScaleFactor] can calculate the correct dpi in macOS. E.g. backingScaleFactor is always 2 in all display modes for rMBP 16" */
             if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_7) {
                 NSRect framePoints = [screen frame];
+                NSRect framePixels = [screen convertRectToBacking:framePoints];
+
                 CGFloat widthPoints  = framePoints.size.width;
                 CGFloat heightPoints = framePoints.size.height;
-                windowsCompatibleDpiW = (displayNativeSize.width / framePoints.size.width) * 96.0;
-                windowsCompatibleDpiH = (displayNativeSize.height / framePoints.size.height) * 96.0;
+                CGFloat widthPixels  = framePixels.size.width;
+                CGFloat heightPixels = framePixels.size.height;
+
+                // SDL_Log ("widthPoints %f    heightPoints %f", widthPoints, heightPoints);
+                // SDL_Log ("widthPixels %f    heightPixels %f", widthPixels, heightPixels);
+
+                windowsCompatibleDpiW = (widthPixels / widthPoints) * 96.0;
+                windowsCompatibleDpiH = (heightPixels / heightPoints) * 96.0;
                 break;
             } else
 #endif


### PR DESCRIPTION
In essence we only need a basic scaling ratio of the back buffer to the resolution the user selects in Settings > Displays.
This is because Mac OS performs scaling for us.